### PR TITLE
Restore support for node 0.8 by using `readable-stream`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var fs     = require('fs');
-var stream = require('stream');
+var stream = require('readable-stream');
 var util   = require('util');
 
 var RE_COMMENT_START = /^\s*\/\*\*\s*$/m;
@@ -193,7 +193,7 @@ function parse_block(source, opts) {
   source = source
     .reduce(function(tags, line) {
       line.source = line.source.trim();
-      
+
       if (line.source.match(/^@(\w+)/)) { 
         tags.push({source: [line.source], line: line.number});
       } else {
@@ -264,10 +264,10 @@ function parse_block(source, opts) {
 
     return tags.concat(tag_node);
   }, []);
-  
+
   // console.log('-----------');
   // console.log(description, tags);
-  
+
   return {
     tags        : tags,
     line        : start,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "directories": {
     "test": "tests"
   },
-  "dependencies": {},
+  "dependencies": {
+    "readable-stream": "^2.0.4"
+  },
   "devDependencies": {
     "chai": "~1.9.0",
     "jshint": "^2.5.10",

--- a/tests/files.spec.js
+++ b/tests/files.spec.js
@@ -1,6 +1,6 @@
 
 var fs     = require('fs');
-var stream = require('stream');
+var stream = require('readable-stream');
 var expect = require('chai').expect
 var parse  = require('../index');
 


### PR DESCRIPTION
With virtually no changes, this PR makes this module (which is used by linters like `jscs`) work in node `0.8`, which I still support on as many of my modules as I can.

I'd consider this a semver-patch change, and if it's merged and released, I'll PR it into `node-jscs` as well.