### PR TITLE
parser: recognize comment lines with joined block start and end

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -1,7 +1,8 @@
 
-var RE_COMMENT_START = /^\s*\/\*\*\s*$/m;
+var RE_COMMENT_START = /^\s*\/\*\*\s*/m;
 var RE_COMMENT_LINE  = /^\s*\*(?:\s(\s*)|$)/m;
 var RE_COMMENT_END   = /^\s*\*\/\s*$/m;
+var RE_COMMENT_JEND  = /^\s*\*\s*(.*)\s*\*\/\s*$/m;
 var RE_COMMENT_1LINE = /^\s*\/\*\*\s*(.*)\s*\*\/\s*$/;
 
 /* ------- util functions ------- */
@@ -303,6 +304,13 @@ function mkextract(opts) {
     if (line.match(RE_COMMENT_START)) {
       chunk = [{source: line.replace(RE_COMMENT_START, ''), number: number - 1}];
       return null;
+    }
+
+    // if comment line with joined end and chunk started
+    // then append and parse
+    if (chunk && line.match(RE_COMMENT_JEND)) {
+      chunk.push({source: line.replace(RE_COMMENT_JEND, '$1'), number: number - 1});
+      return parse_block(chunk, opts);
     }
 
     // if comment line and chunk started

--- a/tests/parse.spec.js
+++ b/tests/parse.spec.js
@@ -55,6 +55,38 @@ describe('Comment string parsing', function() {
       });
   });
 
+  it('should accept a description on the first line', function() {
+    expect(parsed(function(){
+      /** Description first line
+       *
+       * Description second line
+       */
+      var a;
+    })[0])
+      .eql({
+        description : 'Description first line\n\nDescription second line',
+        source      : 'Description first line\n\nDescription second line',
+        line        : 1,
+        tags        : []
+      });
+  });
+
+  it('should accept comment close on a non-empty', function() {
+    expect(parsed(function(){
+      /**
+       * Description first line
+       *
+       * Description second line */
+      var a;
+    })[0])
+      .eql({
+        description : 'Description first line\n\nDescription second line',
+        source      : 'Description first line\n\nDescription second line',
+        line        : 1,
+        tags        : []
+      });
+  });
+
   it('should skip empty blocks', function() {
 
     expect(parsed(function(){


### PR DESCRIPTION
Recognize and retain non-whitespace content on the first line of a
multi-line block comment.

Recognize and retain content on the last line of a multi-line block
comment.

Fixes #22

Signed-off-by: Peter A. Bigot pab@pabigot.com
