### PR TITLE
add line not start with star join previous line options

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -105,8 +105,8 @@ function parse_block (source, opts) {
         tags.push({source: [line.source], line: line.number})
       } else {
         var tag = tags[tags.length - 1]
-        if (opts.join !== undefined && opts.join !== false && opts.join !== 0
-            && !line.startWithStar && tag.source.length > 0) {
+        if (opts.join !== undefined && opts.join !== false && opts.join !== 0 &&
+            !line.startWithStar && tag.source.length > 0) {
           var source
           if (typeof opts.join === 'string') {
             source = opts.join + line.source.replace(/^\s+/, '')

--- a/parser.js
+++ b/parser.js
@@ -105,7 +105,20 @@ function parse_block (source, opts) {
         tags.push({source: [line.source], line: line.number})
       } else {
         var tag = tags[tags.length - 1]
-        tag.source.push(line.source)
+        if (opts.join !== undefined && opts.join !== false && opts.join !== 0
+            && !line.startWithStar && tag.source.length > 0) {
+          var source
+          if (typeof opts.join === 'string') {
+            source = opts.join + line.source.replace(/^\s+/, '')
+          } else if (typeof opts.join === 'number') {
+            source = line.source
+          } else {
+            source = ' ' + line.source.replace(/^\s+/, '')
+          }
+          tag.source[tag.source.length - 1] += source
+        } else {
+          tag.source.push(line.source)
+        }
       }
 
       return tags
@@ -212,6 +225,7 @@ function mkextract (opts) {
     // if we are on middle of comment block
     if (chunk) {
       var lineStart = indent
+      var startWithStar = false
 
       // figure out if we slice from opening marker pos
       // or line start is shifted to the left
@@ -222,6 +236,7 @@ function mkextract (opts) {
       if (chunk.length > 0 && nonSpaceChar) {
         if (nonSpaceChar[0] === '*') {
           lineStart = nonSpaceChar.index + 2
+          startWithStar = true
         } else if (nonSpaceChar.index < indent) {
           lineStart = nonSpaceChar.index
         }
@@ -230,6 +245,7 @@ function mkextract (opts) {
       // slice the line until end or until closing marker start
       chunk.push({
         number: number,
+        startWithStar: startWithStar,
         source: line.slice(lineStart, endPos === -1 ? line.length : endPos)
       })
 

--- a/tests/parse.js
+++ b/tests/parse.js
@@ -4,7 +4,7 @@
  * 0 function() {
  * 1  // source with comments
  * 2 }
- * 
+ *
  */
 
 var parse = require('../index')

--- a/tests/parse.spec.js
+++ b/tests/parse.spec.js
@@ -785,4 +785,83 @@ describe('Comment string parsing', function () {
         }]
       })
   })
+
+  it('should parse multiline without star as same line respecting `opts.join = true`', function () {
+    expect(parse(function () {
+      /**
+       * @tag name
+       * description
+         same line
+       */
+    }, {
+      join: true
+    })[0])
+      .to.eql({
+        line: 1,
+        description: '',
+        source: '@tag name\ndescription\nsame line',
+        tags: [{
+          tag: 'tag',
+          line: 2,
+          type: '',
+          name: 'name',
+          description: 'description same line',
+          source: '@tag name\ndescription same line',
+          optional: false
+        }]
+      })
+  })
+
+  it('should parse multiline without star as same line respecting `opts.join = "\\t"`', function () {
+    expect(parse(function () {
+      /**
+       * @tag name
+       * description
+         same line
+       */
+    }, {
+      join: '\t'
+    })[0])
+      .to.eql({
+        line: 1,
+        description: '',
+        source: '@tag name\ndescription\nsame line',
+        tags: [{
+          tag: 'tag',
+          line: 2,
+          type: '',
+          name: 'name',
+          description: 'description\tsame line',
+          source: '@tag name\ndescription\tsame line',
+          optional: false
+        }]
+      })
+  })
+
+  it('should parse multiline without star as same line with intent respecting `opts.join = 1` and `opts.trim = false`', function () {
+    expect(parse(function () {
+      /**
+       * @tag name
+       * description
+           intent same line
+       */
+    }, {
+      join: 1,
+      trim: false
+    })[0])
+      .to.eql({
+        line: 1,
+        description: '',
+        source: '\n@tag name\ndescription\n  intent same line\n',
+        tags: [{
+          tag: 'tag',
+          line: 2,
+          type: '',
+          name: 'name',
+          description: 'description  intent same line\n',
+          source: '@tag name\ndescription  intent same line\n',
+          optional: false
+        }]
+      })
+  })
 })


### PR DESCRIPTION
With `opts.join`

We can treat  non-star-start line as last part of previous line without a new `\n`

This may help if we need large same line string.

`opts.join` has 4 kinds of value we can choice:

* `true`: join previous line with a space
* `1`: join previous line with block intent
* `(string)`: join previous line with specified string
* `false` or `undefined`: do not join previous line

Could you gave me some advice for this PR?

Thank you!