### PR TITLE
Update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,26 +2,28 @@
 // Project: comment-parser
 // Definitions by: Javier "Ciberman" Mora <https://github.com/jhm-ciberman/>
 
-interface Comment {
-  tags: Tag[];
-  line: number;
-  description: string;
-  source: string;
-}
-interface Tag {
-  tag: string;
-  name: string;
-  optional: boolean;
-  type: string;
-  description: string;
-  line: number;
-  source: string;
-}
-interface Options {
-  parsers?: [(str: string, data: any) => { source: string, data: any }];
-  dotted_names?: boolean;
+declare namespace CommentParser {
+  interface Comment {
+    tags: Tag[];
+    line: number;
+    description: string;
+    source: string;
+  }
+  interface Tag {
+    tag: string;
+    name: string;
+    optional: boolean;
+    type: string;
+    description: string;
+    line: number;
+    source: string;
+  }
+  interface Options {
+    parsers?: [(str: string, data: any) => { source: string, data: any }];
+    dotted_names?: boolean;
+  }
 }
 
-declare function parse(str: string, opts?: Options): [Comment];
+declare function parse(str: string, opts?: CommentParser.Options): [CommentParser.Comment];
 
 export = parse;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,13 +3,13 @@
 // Definitions by: Javier "Ciberman" Mora <https://github.com/jhm-ciberman/>
 
 declare namespace CommentParser {
-  interface Comment {
+  export interface Comment {
     tags: Tag[];
     line: number;
     description: string;
     source: string;
   }
-  interface Tag {
+  export interface Tag {
     tag: string;
     name: string;
     optional: boolean;
@@ -18,7 +18,7 @@ declare namespace CommentParser {
     line: number;
     source: string;
   }
-  interface Options {
+  export interface Options {
     parsers?: [(str: string, data: any) => { source: string, data: any }];
     dotted_names?: boolean;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "comment-parser",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1289,12 +1289,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1309,17 +1311,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1436,7 +1441,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1448,6 +1454,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1462,6 +1469,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1469,12 +1477,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1493,6 +1503,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1573,7 +1584,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1585,6 +1597,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1706,6 +1719,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.2",
   "description": "Generic JSDoc-like comment parser. ",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
I have updated the typings to be according to the official "module-function" template 
"comment-parser" is a module function since it exposes a single function to be called. (for future modules you make, please do not do that, since it is not compatible with the ES6 module import syntax)

https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-function-d-ts.html