### PR TITLE
Stringifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ const stream = require('stream')
 
 const parse = require('./parser')
 
+const stringify = require('./stringifier')
+
 module.exports = parse
+
+module.exports.stringify = stringify
 
 /* ------- Transform stream ------- */
 

--- a/stringifier.js
+++ b/stringifier.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const getIndent = (indent) => {
+  return typeof indent === 'number' ? ' '.repeat(indent) : indent
+}
+
+const stringifyBlocks = exports.stringifyBlocks = function stringifyBlocks (
+  blocks, { indent = '' } = {}
+) {
+  const indnt = getIndent(indent)
+  return blocks.reduce((s, block) => {
+    return s + stringifyBlock(block, { indent })
+  }, '/**\n') + indnt + '*/'
+}
+
+const stringifyBlock = exports.stringifyBlock = function stringifyBlock (
+  block, { indent = '' } = {}
+) {
+  // block.line
+  const indnt = getIndent(indent)
+  return indnt + '* ' + block.description + '\n' + indnt + '*\n' +
+    block.tags.reduce((s, tag) => {
+      return s + stringifyTag(tag, { indent })
+    }, '')
+}
+
+const stringifyTag = exports.stringifyTag = function stringifyTag (
+  tag, { indent = '' } = {}
+) {
+  const indnt = getIndent(indent)
+  const {
+    type, name, optional, description, tag: tagName, default: deflt //, line , source
+  } = tag
+  return indnt + `* @${tagName}` +
+    (type ? ` {${type}}` : '') +
+    (name ? ` ${
+      optional ? '[' : ''
+    }${name}${deflt ? `=${deflt}` : ''}${
+      optional ? ']' : ''
+    }` : '') +
+    (description ? ` ${description.replace(/\n/g, '\n' + indnt + '* ')}` : '') + '\n'
+}
+
+module.exports = function stringify (arg, opts) {
+  if (Array.isArray(arg)) {
+    return stringifyBlocks(arg, opts)
+  }
+  if (arg && typeof arg === 'object') {
+    if ('tag' in arg) {
+      return stringifyTag(arg, opts)
+    }
+    if ('tags' in arg) {
+      return stringifyBlock(arg, opts)
+    }
+  }
+  throw new TypeError('Unexpected argument passed to `stringify`.')
+}

--- a/tests/stringify.spec.js
+++ b/tests/stringify.spec.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const { expect } = require('chai')
+
+const parser = require('../')
+
+describe('Comment stringifying', function () {
+  it('should stringify doc block with description', function () {
+    const expected = `/**
+* Singleline or multiline description text. Line breaks are preserved.
+*
+* @some-tag {Type} name Singleline or multiline description text
+* @some-tag {Type} name.subname Singleline or multiline description text
+* @some-tag {Type} name.subname.subsubname Singleline or
+* multiline description text
+* @some-tag {Type} [optionalName=someDefault]
+* @another-tag
+*/`
+    const parsed = parser(expected)
+
+    expect(parsed).to.be.an('array')
+
+    const stringified = parser.stringify(parsed)
+
+    expect(stringified).to.eq(expected)
+  })
+
+  it('should stringify indented doc block with description', function () {
+    const expected = `/**
+    * Singleline or multiline description text. Line breaks are preserved.
+    *
+    * @some-tag {Type} name Singleline or multiline description text
+    * @some-tag {Type} name.subname Singleline or multiline description text
+    * @some-tag {Type} name.subname.subsubname Singleline or
+    * multiline description text
+    * @some-tag {Type} [optionalName=someDefault]
+    * @another-tag
+    */`
+    const parsed = parser(expected)
+
+    expect(parsed).to.be.an('array')
+
+    const stringified = parser.stringify(parsed, { indent: '    ' })
+
+    expect(stringified).to.eq(expected)
+  })
+
+  it('should stringify numeric indented doc block with description', function () {
+    const expected = `/**
+    * Singleline or multiline description text. Line breaks are preserved.
+    *
+    * @some-tag {Type} name Singleline or multiline description text
+    * @some-tag {Type} name.subname Singleline or multiline description text
+    * @some-tag {Type} name.subname.subsubname Singleline or
+    * multiline description text
+    * @some-tag {Type} [optionalName=someDefault]
+    * @another-tag
+    */`
+    const parsed = parser(expected)
+
+    expect(parsed).to.be.an('array')
+
+    const stringified = parser.stringify(parsed, { indent: 4 })
+
+    expect(stringified).to.eq(expected)
+  })
+})


### PR DESCRIPTION
This builds on #54 and #55 to provide a mechanism for converting (modified) parsed comment JSON back into a string. Supports indent.