### PR TITLE
Indent at start of block

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ This would produce following:
 }]
 ```
 
+## Stringifying
+
+One may also convert `comment-parser` JSON structures back into strings using
+the `stringify` method (`stringify(o:(Object|Array) [, opts:Object]):String`).
+
+This method accepts the JSON as its first argument and an optional options
+object with an `indent` property set to either a string or a number that
+will be used to determine the number of spaces of indent. The indent of the
+start of the doc block will be one space less than the indent of each line of
+asterisks for the sake of alignment as per usual practice.
+
+The `stringify` export delegates to the specialized methods `stringifyBlocks`,
+`stringifyBlock`, and `stringifyTag`, which are available on the `stringify`
+function object.
+
 ## Packaging
 
 `comment-parser` is CommonJS module and was primarely designed to be used with Node. Module `index.js` includes stream and file functionality. Use prser-only module in browser `comment-parser/parse.js`

--- a/stringifier.js
+++ b/stringifier.js
@@ -4,13 +4,28 @@ const getIndent = (indent) => {
   return typeof indent === 'number' ? ' '.repeat(indent) : indent
 }
 
+module.exports = exports = function stringify (arg, opts) {
+  if (Array.isArray(arg)) {
+    return stringifyBlocks(arg, opts)
+  }
+  if (arg && typeof arg === 'object') {
+    if ('tag' in arg) {
+      return stringifyTag(arg, opts)
+    }
+    if ('tags' in arg) {
+      return stringifyBlock(arg, opts)
+    }
+  }
+  throw new TypeError('Unexpected argument passed to `stringify`.')
+}
+
 const stringifyBlocks = exports.stringifyBlocks = function stringifyBlocks (
   blocks, { indent = '' } = {}
 ) {
   const indnt = getIndent(indent)
   return blocks.reduce((s, block) => {
     return s + stringifyBlock(block, { indent })
-  }, '/**\n') + indnt + '*/'
+  }, (indnt ? indnt.slice(0, -1) : '') + '/**\n') + indnt + '*/'
 }
 
 const stringifyBlock = exports.stringifyBlock = function stringifyBlock (
@@ -18,7 +33,7 @@ const stringifyBlock = exports.stringifyBlock = function stringifyBlock (
 ) {
   // block.line
   const indnt = getIndent(indent)
-  return indnt + '* ' + block.description + '\n' + indnt + '*\n' +
+  return (block.description ? `${indnt}* ${block.description}\n${indnt}*\n` : '') +
     block.tags.reduce((s, tag) => {
       return s + stringifyTag(tag, { indent })
     }, '')
@@ -39,19 +54,4 @@ const stringifyTag = exports.stringifyTag = function stringifyTag (
       optional ? ']' : ''
     }` : '') +
     (description ? ` ${description.replace(/\n/g, '\n' + indnt + '* ')}` : '') + '\n'
-}
-
-module.exports = function stringify (arg, opts) {
-  if (Array.isArray(arg)) {
-    return stringifyBlocks(arg, opts)
-  }
-  if (arg && typeof arg === 'object') {
-    if ('tag' in arg) {
-      return stringifyTag(arg, opts)
-    }
-    if ('tags' in arg) {
-      return stringifyBlock(arg, opts)
-    }
-  }
-  throw new TypeError('Unexpected argument passed to `stringify`.')
 }

--- a/tests/stringify.spec.js
+++ b/tests/stringify.spec.js
@@ -26,7 +26,7 @@ describe('Comment stringifying', function () {
   })
 
   it('should stringify indented doc block with description', function () {
-    const expected = `/**
+    const expected = `   /**
     * Singleline or multiline description text. Line breaks are preserved.
     *
     * @some-tag {Type} name Singleline or multiline description text
@@ -46,7 +46,7 @@ describe('Comment stringifying', function () {
   })
 
   it('should stringify numeric indented doc block with description', function () {
-    const expected = `/**
+    const expected = `   /**
     * Singleline or multiline description text. Line breaks are preserved.
     *
     * @some-tag {Type} name Singleline or multiline description text
@@ -55,6 +55,19 @@ describe('Comment stringifying', function () {
     * multiline description text
     * @some-tag {Type} [optionalName=someDefault]
     * @another-tag
+    */`
+    const parsed = parser(expected)
+
+    expect(parsed).to.be.an('array')
+
+    const stringified = parser.stringify(parsed, { indent: 4 })
+
+    expect(stringified).to.eq(expected)
+  })
+
+  it('should stringify numeric indented doc block without description', function () {
+    const expected = `   /**
+    * @param Foo
     */`
     const parsed = parser(expected)
 


### PR DESCRIPTION
- Change: Add indent to start of block
- Fix: Ensure `stringifyBlocks`, `stringifyBlock`, and `stringifyTag` are exposed on `stringify`
- Fix: Avoid newlines with missing description
- Docs: Document `stringify` methods

Apologies, I have a few tweaks and docs here I should have added previously.

I think the indent at the start of the block is useful since the indent is generally one space less than the indent before each other line beginning with asterisks, and I think it is more convenient to handle this for the user.